### PR TITLE
Added CMake Build System

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+out/
+.vs/
+CMakeSettings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.28)
+
+project(PkgDecrypt)
+
+add_subdirectory(libb64)
+add_subdirectory(aes)
+add_subdirectory(zlib)
+
+add_library(keyflate STATIC keyflate.c)
+target_link_libraries(keyflate PRIVATE ZLIB::ZLIB)
+
+add_executable(make_key make_key.c)
+target_link_libraries(make_key PRIVATE b64 keyflate)
+target_include_directories(make_key PRIVATE libb64)
+# Couple EXE with zlib DLL on Windows and bundle other things together. Grabbed from here: https://stackoverflow.com/a/75065206
+# Hoping this isn't needed with the zlib-cmake project, but it's here just in case.
+# install(TARGETS make_key
+#   RUNTIME ARCHIVE LIBRARY RUNTIME FRAMEWORK BUNDLE PUBLIC_HEADER RESOURCE)
+
+add_executable(pkg_dec pkg_dec.c)
+target_link_libraries(pkg_dec PRIVATE b64 keyflate aes)
+target_include_directories(pkg_dec PRIVATE libb64)
+# Couple EXE with zlib DLL on Windows and bundle other things together. Grabbed from here: https://stackoverflow.com/a/75065206
+# Hoping this isn't needed with the zlib-cmake project, but it's here just in case.
+# install(TARGETS pkg_dec
+#    RUNTIME ARCHIVE LIBRARY RUNTIME FRAMEWORK BUNDLE PUBLIC_HEADER RESOURCE)

--- a/aes/CMakeLists.txt
+++ b/aes/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.13)
+project(aes)
+
+set(SOURCE_FILES
+aes.c
+)
+
+add_library(${PROJECT_NAME} ${SOURCE_FILES})

--- a/libb64/CMakeLists.txt
+++ b/libb64/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.28)
+# set(CMAKE_C_STANDARD)
+# set(CMAKE_CXX_STANDARD)
+
+project(b64)
+
+add_subdirectory(b64)
+
+set(SOURCE_FILES
+cdecode.c
+cencode.c
+)
+add_library(${PROJECT_NAME} ${SOURCE_FILES})
+include_directories(.)

--- a/libb64/b64/CMakeLists.txt
+++ b/libb64/b64/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.28)
+# target_sources(PRIVATE FILE_SET b64
+# 	TYPE HEADERS
+#	FILES cdecrypt.h
+#	cencrypt.h)
+# target_sources(PUBLIC FILE-SET testset TYPE HEADERS FILES 
+# cdecrypt.h
+# cencrypt.h
+# )
+include_directories(b64, AFTER PRIVATE
+cdecrypt.h
+cencrypt.h
+)

--- a/zlib/CMakeLists.txt
+++ b/zlib/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Downloads ZLIB-1.3.1 if it's not already available. Uses: https://github.com/jimmy-park/zlib-cmake
+
+cmake_minimum_required(VERSION 3.28)
+include(FetchContent)
+
+FetchContent_Declare(
+    zlib-cmake
+    URL https://github.com/jimmy-park/zlib-cmake/archive/main.zip
+)
+FetchContent_MakeAvailable(zlib-cmake)
+
+
+
+# This is my previous failed attempt. It required downloading ZLIB manually and is errorprone.
+# If ZLIB-NG is prefered, I found that building ZLIB as a shared library and replacing the Windows
+# DLL with a prebuilt version of ZLIB-NG works well enough, though is too hacky. I'd prefer to
+# build ZLIB-NG along with PkgDecrypt and any other project.
+
+# set(USED_ZLIB_LIBRARY zlib-1.3.1 CACHE STRING "What flavor of ZLIB to use")
+
+# if(${USED_ZLIB_LIBRARY} EQUAL zlib-1.3.1)
+#   add_subdirectories(${CMAKE_CURRENT_BINARY_DIR}/zlib_build)
+#   set(ZLIB_BUILD_EXAMPLES OFF)
+# endif()
+
+# if(${USED_ZLIB_LIBRARY} EQUAL zlib-ng-develop)
+# TODO: Fix this. Include names not correct.
+# endif()
+
+# add_subdirectory(${USED_ZLIB_LIBRARY})


### PR DESCRIPTION
I have added a CMake build system and a .gitignore.
A CMake file is within the zlib directory to grab and set it up automatically. This is what it downloads: https://github.com/jimmy-park/zlib-cmake . This is compiling successfully on both windows 11 MSVC and Android Termux Clang.

An attempt was made to get zlib-ng working without any source code changes, but that attempt failed. The old attempt is commented out in zlib/CMakeLists.txt in case anyone wants to try getting it working.